### PR TITLE
Remove services.AddTransient<IRulesRepo, RulesRepo> in StartUp

### DIFF
--- a/src/AutoStateTransitions/Startup.cs
+++ b/src/AutoStateTransitions/Startup.cs
@@ -50,8 +50,6 @@ namespace AutoStateTransitions
             services.AddTransient<IHelper, Helper>();
 
             services.AddTransient<IWorkItemRepo, WorkItemRepo>();
-            services.AddTransient<IRulesRepo, RulesRepo>();
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Remove services.AddTransient<IRulesRepo, RulesRepo> for rules based on similar run-time issues reported at https://github.com/aspnet/Extensions/issues/1079. Fixes my http 500 errors when hitting the api.