### PR TITLE
Fixes issue with project not launching in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/AutoStateTransitions/bin/Debug/netcoreapp2.2/AutoStateTransitions.dll",
+            "program": "${workspaceFolder}/src/AutoStateTransitions/bin/Debug/netcoreapp3.1/AutoStateTransitions.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/AutoStateTransitions",
             "stopAtEntry": false,


### PR DESCRIPTION
The launch file was expecting the dll to be in the wrong location.

Changing the expected location from 2.2 it to 3.1 fixes the issue.

Fixes #22 